### PR TITLE
Update stage with missing modules

### DIFF
--- a/build/contrib.make
+++ b/build/contrib.make
@@ -146,7 +146,7 @@ projects:
   menu_attributes:
     type: module
     subdir: contrib
-    version: "1.0+1-dev"
+    version: "1.x-dev"
   menu_block:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -146,7 +146,7 @@ projects:
   menu_attributes:
     type: module
     subdir: contrib
-    version: "1.0+1-dev"
+    version: "1.0"
   mobile_navigation:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -146,7 +146,15 @@ projects:
   menu_attributes:
     type: module
     subdir: contrib
-    version: "1.x-dev"
+    version: "1.0+1-dev"
+  menu_block:
+    type: module
+    subdir: contrib
+    version: "2.7"  
+  metatag:
+    type: module
+    subdir: contrib
+    version: "1.6"           
   mobile_navigation:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -139,6 +139,14 @@ projects:
     type: module
     subdir: contrib
     version: "1.5"
+  menu_block:
+    type: module
+    subdir: contrib
+    version: "2.7"    
+  menu_attributes:
+    type: module
+    subdir: contrib
+    version: "1.0+1-dev"    
   module_filter:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -146,7 +146,7 @@ projects:
   menu_attributes:
     type: module
     subdir: contrib
-    version: "1.0"
+    version: "1.x-dev"
   mobile_navigation:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -181,6 +181,10 @@ projects:
     type: module
     subdir: contrib
     version: "2.3"
+  qtip:
+    type: module
+    subdir: contrib
+    version: "2.0-rc3"  
   redirect:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -146,7 +146,11 @@ projects:
   menu_attributes:
     type: module
     subdir: contrib
-    version: "1.0+1-dev"    
+    version: "1.0+1-dev"
+  mobile_navigation:
+    type: module
+    subdir: contrib
+    version: "1.2"     
   module_filter:
     type: module
     subdir: contrib

--- a/build/contrib.make
+++ b/build/contrib.make
@@ -147,6 +147,10 @@ projects:
     type: module
     subdir: contrib
     version: "1.0+1-dev"
+  metatag:
+    type: module
+    subdir: contrib
+    version: "1.6"       
   mobile_navigation:
     type: module
     subdir: contrib


### PR DESCRIPTION
Looks like the modules were downloaded into the stage site and enabled but not as part of the build process.
